### PR TITLE
1.5.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,7 +8,10 @@ jobs:
     container:
       image:  google/dart:latest
     steps:
-      - uses: actions/checkout@v1
+      - name: export tag
+        run: echo "RELEASE_VERSION=v${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: preparation
+        uses: actions/checkout@v1
       - name: Setup credentials
         run: |
           mkdir -p ~/.pub-cache
@@ -23,3 +26,9 @@ jobs:
           EOF
       - name: Publish package
         run: pub publish -f
+      - name: release version
+        uses: ncipollo/release-action@v1
+        with:
+            tag: {{ env.RELEASE_VERSION }}
+            name: {{ env.RELEASE_VERSION }}
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -31,4 +31,4 @@ jobs:
         with:
             tag: {{ env.RELEASE_VERSION }}
             name: {{ env.RELEASE_VERSION }}
-            token: ${{ secrets.GITHUB_TOKEN }}
+            token: {{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -29,6 +29,6 @@ jobs:
       - name: release version
         uses: ncipollo/release-action@v1
         with:
-            tag: {{ env.RELEASE_VERSION }}
-            name: {{ env.RELEASE_VERSION }}
-            token: {{ secrets.GITHUB_TOKEN }}
+            tag: ${{ env.RELEASE_VERSION }}
+            name: ${{ env.RELEASE_VERSION }}
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.0] - add styles for SimpleGroupedCheckbox,SimpleGroupedChips,SimpleGroupedSwitch 
+*  create new generic `GroupedStyle` to manage style of simple_grouped_checkbox 
+*  deprecate `backgroundColorItem`,`selectedColorItem`,`textColor`,`selectedTextColor`,`selectedIcon`,`disabledColor` 
+*  add `chipGroupStyle` in SimpleGroupedChips 
+*  add `SwitchGroupStyle` style for SimpleGroupedSwitch 
+*  add `SwitchGroupStyle` style for SimpleGroupedSwitch 
 ## [1.4.2] - fix bugs 
 *  fix bugs in helper expandable simple grouped 
 ## [1.4.1] - fix bugs 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # checkbox_grouped
-![pub](https://img.shields.io/badge/pub-v1.4.2-orange) ![GitHub](https://img.shields.io/github/license/liodali/checkbox_grouped)
+![pub](https://img.shields.io/badge/pub-v1.5.0-orange) ![GitHub](https://img.shields.io/github/license/liodali/checkbox_grouped)
 
     * grouped (checkbox/radioButton)
     * customisable grouped checkbox
@@ -19,7 +19,7 @@
 Add the following to your `pubspec.yaml` file:
 
     dependencies:
-		checkbox_grouped: ^1.4.2
+		checkbox_grouped: ^1.5.0
 
 
 
@@ -31,7 +31,12 @@ Add the following to your `pubspec.yaml` file:
                     controller: controller,
                     itemsTitle: ["1" ,"2","4","5"],
                     values: [1,2,4,5],
-                    activeColor: Colors.red,
+                    groupStyle: GroupStyle(
+                          activeColor: Colors.red,
+                          itemTitleStyle: TextStyle(
+                          fontSize: 13
+                       )
+                    ),
                     checkFirstElement: false,
                     multiSelection: false,
                   )
@@ -104,7 +109,7 @@ controller.listen((v) {
 |   Properties          |  Description |
 |-----------------------|--------------|
 |`controller`           | (required)  Group Controller to recuperate selectionItems and disable or enableItems.  |
-|`activeColor`          | The color to use when a CheckBox is checked.  |
+|`activeColor`          | (deprecated) The color to use when a CheckBox is checked.  |
 |`itemsTitle`           | (required) A list of strings that describes each checkbox button. Each label must be distinct.   |
 |`itemsSubTitle`        | A list of strings that describes second Text.   |
 |`onItemSelected`       | Callback fire when the user make  selection    |
@@ -113,9 +118,10 @@ controller.listen((v) {
 |`checkFirstElement`    | `make first element in list checked`.  |
 |`isExpandableTitle`    | `enable group checkbox to be expandable `.  |
 |`groupTitle`           | `Text title for group checkbox`.  |
-|`groupTitleStyle`      | `TextStyle of title for group checkbox`.  |
+|`groupTitleStyle`      | (deprecated) `TextStyle of title for group checkbox`.  |
 |`helperGroupTitle`     | `(bool) hide/show checkbox in title to help all selection or de-selection,use it when you want to disable checkbox in groupTitle default:true `.  |
 |`groupTitleAlignment`  | `(Alignment) alignment of group title in group checkbox`.  |
+|`groupStyle`           | `(GroupStyle)  (GroupStyle) the style that should be applied on GroupedTitle,ItemTile,SubTitle`.  |
 
 ## Customisable Checkbox Grouped
 
@@ -214,7 +220,12 @@ SimpleGroupedChips<int>(
                     controller: controller,
                     values: [1,2,3,4,5,6,7],
                     itemTitle: ["1" ,"2","4","5","6","7"],
-                    backgroundColorItem: Colors.black26,
+                    chipGroupStyle: ChipGroupStyle.minimize(
+                         backgroundColorItem: Colors.red[400],
+                         itemTitleStyle: TextStyle(
+                         fontSize: 14,
+                      ),
+                    ),
                   )
 ```
 ### Declare GroupController to get selection and enabled/disabled Items
@@ -228,6 +239,7 @@ GroupController controller = GroupController();
 |-----------------------|--------------|
 |`isMultipleSelection`  | (bool) enable multiple selection  in grouped checkbox (default:false).  |
 |`initSelectedItem`     | (List) A Initialize list of values that will be selected in grouped.   |
+|`chipGroupStyle`       | (ChipGroupStyle) A Initialize list of values that will be selected in grouped.   |
 
 
 ### Get current selection
@@ -258,17 +270,19 @@ controller.disabledItemsByTitles(List<String> items)
 ####  `SimpleGroupedChip`
 |   Properties          |  Description |
 |-----------------------|--------------|
-|`controller`           | (required) Group Controller to recuperate selectionItems and disable or enableItems.  |
-|`itemsTitle`           | (required) A list of strings that describes each chip button. Each label must be distinct.   |
-|`disabledItems`        | Specifies which item should be disabled. The strings passed to this must match the Titles  |
+|`controller`           | (required) `controller to recuperate selectionItems and disable or enableItems.`  |
+|`itemsTitle`           | (required) `A list of strings that describes each chip button. Each label must be distinct.`   |
+|`disabledItems`        | `Specifies which item should be disabled. The strings passed to this must match the Titles`  |
 |`values`               | (required) Values contains in each element.   |
-|`onItemSelected`       | Callback when users make  selection  or deselection  |
-|`backgroundColorItem`  |`the background color for each item`.  |
-|`selectedColorItem`    |`the background color to use when item is  selected`.  |
-|`textColor`            |`the color to use for each text of item `.  |
-|`selectedTextColor`    |`the color to use for the selected text of item`.  |
-|`selectedIcon`         |`the icon to use when item is selected`.  |
+|`onItemSelected`       | `Callback when users make  selection  or deselection`  |
+|`backgroundColorItem`  | (deprecated) `the background color for each item`.  |
+|`selectedColorItem`    | (deprecated) `the background color to use when item is  selected`.  |
+|`textColor`            | (deprecated) `the color to use for each text of item `.  |
+|`selectedTextColor`    | (deprecated) `the color to use for the selected text of item`.  |
+|`selectedIcon`         | (deprecated) `the icon to use when item is selected`.  |
+|`disabledColor`         | (deprecated) `the Color that uses when the item is disabled`  |
 |`isScrolling`          |`enable horizontal scrolling`.  |
+|`chipGroupStyle`       | (ChipGroupStyle) `the style that uses to customize  item chip `  |
 			     
 ## Switch grouped Usage
 
@@ -279,8 +293,14 @@ SimpleGroupedSwitch<int>(
                     controller: controller,
                     values: [1,2,4,5],
                     itemsTitle: ["1 " ,"2 ","4 ","5 ","6","7"],
-                    isMutlipleSelection: false,
-                  )
+                    groupStyle: SwitchGroupStyle(
+                        itemTitleStyle: TextStyle(
+                          fontSize: 16,
+                          color: Colors.blue,
+                       ),
+                     activeColor: Colors.red,
+                  ),  
+             )
 ```
 ### Declare GroupController to get selection and enabled/disabled Items
 
@@ -328,6 +348,7 @@ controller.disabledItemsByTitles(List<String> items)
 |`values`               | (required) Values contains in each element.   |
 |`disableItems`         | Specifies which item should be disabled. The value passed to this must match the values list |
 |`onItemSelected`       | Call when users make  selection  or deselection  |
+|`groupStyle`           | (SwitchGroupStyle) the style that will customize text,switch  |
 
 
 ## showDialogGroupedCheckbox

--- a/example/lib/grid_of_grouped_checkbox.dart
+++ b/example/lib/grid_of_grouped_checkbox.dart
@@ -26,6 +26,13 @@ class GridOfListGroupedCheckbox extends StatelessWidget {
             child: SimpleGroupedCheckbox(
               controller: listOfController[index],
               groupTitle: faker.company.position(),
+              groupStyle: GroupStyle(
+                itemTitleStyle: TextStyle(
+                    fontSize: 12,
+                    color: Colors.brown
+                ),
+                activeColor: Colors.amber
+              ),
               helperGroupTitle: false,
               values: data,
               itemsTitle: data,

--- a/example/lib/grid_of_grouped_checkbox.dart
+++ b/example/lib/grid_of_grouped_checkbox.dart
@@ -37,7 +37,7 @@ class GridOfListGroupedCheckbox extends StatelessWidget {
       primary: true,
       scrollDirection: Axis.vertical,
       child: Container(
-        height: 368*5.1,
+        height: 368 * 5.1,
         child: Column(
           mainAxisSize: MainAxisSize.max,
           children: [

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,7 +60,6 @@ class _MainExampleState extends State<MainExample>
     current.value = tabController.index;
   }
 
-
   @override
   void initState() {
     super.initState();
@@ -172,7 +171,10 @@ class _SimpleGrouped extends StatelessWidget {
             disableItems: ["5"],
             itemsTitle: ["1", "2", "4", "5"],
             values: [1, 2, 4, 5],
-            activeColor: Colors.red,
+            groupStyle: GroupStyle(
+                activeColor: Colors.red,
+                itemTitleStyle: TextStyle(fontSize: 13)),
+
             checkFirstElement: false,
           ),
           SimpleGroupedCheckbox<int>(
@@ -196,6 +198,12 @@ class _SimpleGrouped extends StatelessWidget {
             itemTitle: List.generate(7, (index) => "chip_text_$index"),
             backgroundColorItem: Colors.black26,
             isScrolling: false,
+            chipGroupStyle: ChipGroupStyle.minimize(
+              backgroundColorItem: Colors.red[400],
+              itemTitleStyle: TextStyle(
+                fontSize: 14,
+              ),
+            ),
             onItemSelected: (values) {
               print(values);
             },
@@ -207,8 +215,13 @@ class _SimpleGrouped extends StatelessWidget {
             itemsTitle: List.generate(10, (index) => "$index"),
             values: List.generate(10, (index) => index),
             disableItems: [2],
-            textStyle: TextStyle(fontSize: 16),
-            activeColor: Colors.red,
+            groupStyle: SwitchGroupStyle(
+              itemTitleStyle: TextStyle(
+                fontSize: 16,
+                color: Colors.blue,
+              ),
+              activeColor: Colors.red,
+            ),
             onItemSelected: (values) {
               print(values);
             },

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.2"
+    version: "1.5.0"
   clock:
     dependency: transitive
     description:

--- a/lib/checkbox_grouped.dart
+++ b/lib/checkbox_grouped.dart
@@ -12,3 +12,4 @@ export 'src/widgets/simple_grouped_checkbox.dart'
 export 'src/widgets/simple_grouped_chips.dart' hide SimpleGroupedChipsState;
 export 'src/widgets/simple_grouped_switch.dart' hide SimpleGroupedSwitchState;
 export 'src/common/utilities.dart';
+export 'src/common/grouped_style.dart';

--- a/lib/src/common/grouped_style.dart
+++ b/lib/src/common/grouped_style.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-/// [_BaseGroupedStyle]: base class for style groupedCheckbox,Switch,Chips
+
+///
+/// class [_BaseGroupedStyle]  base class for style groupedCheckbox,Switch,Chips
 ///
 /// [activeColor]        : (Color) choose the color to use when this checkbox button is selected
 ///
@@ -14,7 +16,7 @@ class _BaseGroupStyle {
   final TextStyle? itemTitleStyle;
   final TextStyle? subItemTitleStyle;
 
-  _BaseGroupStyle({
+  const _BaseGroupStyle({
     this.activeColor,
     this.groupTitleStyle,
     this.itemTitleStyle,
@@ -22,6 +24,8 @@ class _BaseGroupStyle {
   });
 }
 
+///
+/// class [GroupedStyle]   for style text in  [SimpleGroupedCheckbox]
 class GroupStyle extends _BaseGroupStyle {
   GroupStyle({
     Color? activeColor,
@@ -33,5 +37,58 @@ class GroupStyle extends _BaseGroupStyle {
           groupTitleStyle: groupTitleStyle,
           itemTitleStyle: itemTitleStyle,
           subItemTitleStyle: subItemTitleStyle,
+        );
+}
+
+///
+/// class [ChipGroupStyle]   for style text in  [SimpleGroupedCheckbox]
+///
+///  [backgroundColorItem]  : the background color for each item
+///
+///  [selectedColorItem]   : the background color to use when item is  selected
+///
+///  [textColor]          : the color to use for each text of item
+///
+///  [selectedTextColor] : the selected color to use for each text of item
+///
+///  [selectedIcon]     : the selected icon to use for each selected  item
+///
+/// [disabledColor]    : (Color) the Color that uses when the item is disabled
+class ChipGroupStyle extends _BaseGroupStyle {
+  final Color? backgroundColorItem;
+  final Color? disabledColor;
+  final Color? selectedColorItem;
+  final Color? textColor;
+  final Color? selectedTextColor;
+  final IconData? selectedIcon;
+
+  const ChipGroupStyle({
+    required this.backgroundColorItem,
+    required this.selectedColorItem,
+    required this.textColor,
+    required this.selectedTextColor,
+    this.selectedIcon,
+    this.disabledColor,
+    TextStyle? itemTitleStyle,
+  }) : super(
+          activeColor: selectedColorItem,
+          groupTitleStyle: null,
+          itemTitleStyle: itemTitleStyle,
+          subItemTitleStyle: null,
+        );
+
+  const ChipGroupStyle.minimize({
+    this.backgroundColorItem = Colors.grey,
+    this.selectedColorItem = Colors.black,
+    this.textColor = Colors.black,
+    this.selectedTextColor = Colors.white,
+    this.selectedIcon = Icons.done,
+    this.disabledColor = Colors.grey,
+    TextStyle? itemTitleStyle,
+  }) : super(
+          activeColor: selectedColorItem,
+          groupTitleStyle: null,
+          itemTitleStyle: itemTitleStyle,
+          subItemTitleStyle: null,
         );
 }

--- a/lib/src/common/grouped_style.dart
+++ b/lib/src/common/grouped_style.dart
@@ -92,3 +92,14 @@ class ChipGroupStyle extends _BaseGroupStyle {
           subItemTitleStyle: null,
         );
 }
+///
+/// class [SwitchGroupStyle]   for style text in  [SimpleGroupedSwitch]
+class SwitchGroupStyle extends _BaseGroupStyle {
+  SwitchGroupStyle({
+    Color? activeColor,
+    TextStyle? itemTitleStyle,
+  }) : super(
+    activeColor: activeColor,
+    itemTitleStyle: itemTitleStyle,
+  );
+}

--- a/lib/src/common/grouped_style.dart
+++ b/lib/src/common/grouped_style.dart
@@ -92,6 +92,7 @@ class ChipGroupStyle extends _BaseGroupStyle {
           subItemTitleStyle: null,
         );
 }
+
 ///
 /// class [SwitchGroupStyle]   for style text in  [SimpleGroupedSwitch]
 class SwitchGroupStyle extends _BaseGroupStyle {
@@ -99,7 +100,7 @@ class SwitchGroupStyle extends _BaseGroupStyle {
     Color? activeColor,
     TextStyle? itemTitleStyle,
   }) : super(
-    activeColor: activeColor,
-    itemTitleStyle: itemTitleStyle,
-  );
+          activeColor: activeColor,
+          itemTitleStyle: itemTitleStyle,
+        );
 }

--- a/lib/src/common/grouped_style.dart
+++ b/lib/src/common/grouped_style.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+/// [_BaseGroupedStyle]: base class for style groupedCheckbox,Switch,Chips
+///
+/// [activeColor]        : (Color) choose the color to use when this checkbox button is selected
+///
+/// [groupTitleStyle]    : (TextStyle) Text Style  that describe style of group title of group checkbox
+///
+/// [itemTitleStyle]     : (TextStyle) Text Style  that describe style of title of each item in  group checkbox
+///
+/// [subItemTitleStyle]  : (TextStyle) Text Style  that describe style of subtitle of each item in  group checkbox
+class _BaseGroupedStyle {
+  final Color? activeColor;
+  final TextStyle? groupTitleStyle;
+  final TextStyle? itemTitleStyle;
+  final TextStyle? subItemTitleStyle;
+
+  _BaseGroupedStyle({
+    this.activeColor,
+    this.groupTitleStyle,
+    this.itemTitleStyle,
+    this.subItemTitleStyle,
+  });
+}
+
+class GroupedStyle extends _BaseGroupedStyle {
+  GroupedStyle({
+    Color? activeColor,
+    TextStyle? groupTitleStyle,
+    TextStyle? itemTitleStyle,
+    TextStyle? subItemTitleStyle,
+  }) : super(
+          activeColor: activeColor,
+          groupTitleStyle: groupTitleStyle,
+          itemTitleStyle: itemTitleStyle,
+          subItemTitleStyle: subItemTitleStyle,
+        );
+}

--- a/lib/src/common/grouped_style.dart
+++ b/lib/src/common/grouped_style.dart
@@ -8,13 +8,13 @@ import 'package:flutter/material.dart';
 /// [itemTitleStyle]     : (TextStyle) Text Style  that describe style of title of each item in  group checkbox
 ///
 /// [subItemTitleStyle]  : (TextStyle) Text Style  that describe style of subtitle of each item in  group checkbox
-class _BaseGroupedStyle {
+class _BaseGroupStyle {
   final Color? activeColor;
   final TextStyle? groupTitleStyle;
   final TextStyle? itemTitleStyle;
   final TextStyle? subItemTitleStyle;
 
-  _BaseGroupedStyle({
+  _BaseGroupStyle({
     this.activeColor,
     this.groupTitleStyle,
     this.itemTitleStyle,
@@ -22,8 +22,8 @@ class _BaseGroupedStyle {
   });
 }
 
-class GroupedStyle extends _BaseGroupedStyle {
-  GroupedStyle({
+class GroupStyle extends _BaseGroupStyle {
+  GroupStyle({
     Color? activeColor,
     TextStyle? groupTitleStyle,
     TextStyle? itemTitleStyle,

--- a/lib/src/widgets/simple_grouped_checkbox.dart
+++ b/lib/src/widgets/simple_grouped_checkbox.dart
@@ -54,7 +54,7 @@ class SimpleGroupedCheckbox<T> extends StatefulWidget {
   final List<String> itemsSubTitle;
   @Deprecated("should use `groupStyle`,will be remove in next version")
   final Color? activeColor;
-  final GroupedStyle? groupStyle;
+  final GroupStyle? groupStyle;
   final List<T> values;
   final List<String> disableItems;
   final bool checkFirstElement;
@@ -176,7 +176,10 @@ class SimpleGroupedCheckboxState<T>
               selectedValue: selectedValue.value,
               value: widget.values[i],
               activeColor: widget.groupStyle?.activeColor ?? widget.activeColor,
-              itemStyle: widget.groupStyle?.itemTitleStyle,
+              itemStyle: widget.groupStyle?.itemTitleStyle?.copyWith(
+                  color: item.checked!
+                      ? widget.groupStyle?.activeColor ?? widget.activeColor
+                      : widget.groupStyle?.itemTitleStyle?.color),
               isLeading: widget.isLeading,
               itemSubTitle: widget.itemsSubTitle.isNotEmpty
                   ? widget.itemsSubTitle[i]

--- a/lib/src/widgets/simple_grouped_checkbox.dart
+++ b/lib/src/widgets/simple_grouped_checkbox.dart
@@ -157,6 +157,7 @@ class SimpleGroupedCheckboxState<T>
               selectedValue: selectedValue.value,
               value: widget.values[i],
               activeColor: widget.activeColor,
+              itemStyle: widget.itemTextStyle,
               isLeading: widget.isLeading,
               itemSubTitle: widget.itemsSubTitle.isNotEmpty
                   ? widget.itemsSubTitle[i]
@@ -395,12 +396,14 @@ class _CheckboxItem<T> extends StatelessWidget {
   final String? itemSubTitle;
   final int index;
   final Color? activeColor;
+  final TextStyle? itemStyle;
   final Function(int i, dynamic v) onChangedCheckBox;
 
   _CheckboxItem({
     this.isMultipleSelection = false,
     this.isLeading = false,
     this.activeColor,
+    this.itemStyle,
     required this.item,
     this.itemSubTitle,
     required this.value,
@@ -422,7 +425,8 @@ class _CheckboxItem<T> extends StatelessWidget {
         activeColor: activeColor ?? Theme.of(context).primaryColor,
         title: AutoSizeText(
           "${item.title}",
-          minFontSize: 12,
+          style: itemStyle,
+          minFontSize: 9,
         ),
         subtitle: itemSubTitle != null
             ? AutoSizeText(
@@ -451,7 +455,8 @@ class _CheckboxItem<T> extends StatelessWidget {
       activeColor: activeColor ?? Theme.of(context).primaryColor,
       title: AutoSizeText(
         item.title,
-        minFontSize: 12,
+        style: itemStyle,
+        minFontSize: 9,
       ),
       subtitle: itemSubTitle != null
           ? AutoSizeText(

--- a/lib/src/widgets/simple_grouped_checkbox.dart
+++ b/lib/src/widgets/simple_grouped_checkbox.dart
@@ -13,6 +13,7 @@ typedef onChanged = Function(dynamic selected);
 /// display  simple groupedCheckbox
 /// [controller] :  (required) Group Controller to recuperate selection Items and disable or enableItems
 /// [itemsTitle] :  (required) A list of strings that describes each checkbox button
+/// [itemTextStyle] : (TextStyle) A text style of item title
 /// [values] : list of values
 /// [onItemSelected] :(callback) callback to receive item selected when it selected directly(callback) callback to receive item selected when it selected directly
 /// [itemsSubTitle] : A list of strings that describes second Text
@@ -32,6 +33,7 @@ class SimpleGroupedCheckbox<T> extends StatefulWidget {
   final String? groupTitle;
   final AlignmentGeometry groupTitleAlignment;
   final TextStyle? groupTitleStyle;
+  final TextStyle? itemTextStyle;
   final List<String> itemsSubTitle;
   final Color? activeColor;
   final List<T> values;
@@ -50,6 +52,7 @@ class SimpleGroupedCheckbox<T> extends StatefulWidget {
     this.groupTitle,
     this.groupTitleAlignment = Alignment.center,
     this.groupTitleStyle,
+    this.itemTextStyle,
     this.itemsSubTitle = const [],
     this.disableItems = const [],
     this.activeColor,

--- a/lib/src/widgets/simple_grouped_checkbox.dart
+++ b/lib/src/widgets/simple_grouped_checkbox.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:checkbox_grouped/src/common/grouped_style.dart';
 import 'package:checkbox_grouped/src/controller/group_controller.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/foundation.dart';
@@ -8,34 +9,52 @@ import 'package:flutter/rendering.dart';
 import '../common/item.dart';
 import '../common/state_group.dart';
 
-typedef onChanged = Function(dynamic selected);
+typedef OnChanged = Function(dynamic selected);
 
 /// display  simple groupedCheckbox
+///
 /// [controller] :  (required) Group Controller to recuperate selection Items and disable or enableItems
+///
 /// [itemsTitle] :  (required) A list of strings that describes each checkbox button
-/// [itemTextStyle] : (TextStyle) A text style of item title
+///
 /// [values] : list of values
+///
 /// [onItemSelected] :(callback) callback to receive item selected when it selected directly(callback) callback to receive item selected when it selected directly
+///
 /// [itemsSubTitle] : A list of strings that describes second Text
+///
 /// [groupTitle] : Text Widget that describe Title of group checkbox
+///
 /// [groupTitleStyle] : Text Style  that describe style of title of group checkbox
-/// [activeColor] : the color to use when this checkbox button is selected
+///
+/// [activeColor] : (Color) the color to use when this checkbox button is selected (deprecated)
+///
+/// [groupStyle] : (GroupStyle) the style that should be applied on GroupedTitle,ItemTile,SubTitle
+///
 /// [disableItems] : specifies which item should be disabled
+///
 /// [checkFirstElement] : make first element in list checked
-/// [isLeading] : same as [itemExtent] of [ListView]
-/// [isExpandableTitle] : enable group checkbox to be expandable
+///
+/// [isLeading] : (bool) put check zone on left of item
+///
+/// [isExpandableTitle] :(bool) enable group checkbox to be expandable
+///
 /// [helperGroupTitle] : (bool) hide/show checkbox in title to help all selection or deselection,use it when you want to disable checkbox in groupTitle default:`true`
+///
 /// [groupTitleAlignment] : (Alignment) align title of checkbox group checkbox default:`Alignment.center`
+///
 class SimpleGroupedCheckbox<T> extends StatefulWidget {
   final GroupController controller;
   final List<String> itemsTitle;
-  final onChanged? onItemSelected;
+  final OnChanged? onItemSelected;
   final String? groupTitle;
   final AlignmentGeometry groupTitleAlignment;
+  @Deprecated("should use `groupStyle`,will be remove in next version")
   final TextStyle? groupTitleStyle;
-  final TextStyle? itemTextStyle;
   final List<String> itemsSubTitle;
+  @Deprecated("should use `groupStyle`,will be remove in next version")
   final Color? activeColor;
+  final GroupedStyle? groupStyle;
   final List<T> values;
   final List<String> disableItems;
   final bool checkFirstElement;
@@ -51,8 +70,8 @@ class SimpleGroupedCheckbox<T> extends StatefulWidget {
     this.onItemSelected,
     this.groupTitle,
     this.groupTitleAlignment = Alignment.center,
+    this.groupStyle,
     this.groupTitleStyle,
-    this.itemTextStyle,
     this.itemsSubTitle = const [],
     this.disableItems = const [],
     this.activeColor,
@@ -156,8 +175,8 @@ class SimpleGroupedCheckboxState<T>
               },
               selectedValue: selectedValue.value,
               value: widget.values[i],
-              activeColor: widget.activeColor,
-              itemStyle: widget.itemTextStyle,
+              activeColor: widget.groupStyle?.activeColor ?? widget.activeColor,
+              itemStyle: widget.groupStyle?.itemTitleStyle,
               isLeading: widget.isLeading,
               itemSubTitle: widget.itemsSubTitle.isNotEmpty
                   ? widget.itemsSubTitle[i]

--- a/lib/src/widgets/simple_grouped_chips.dart
+++ b/lib/src/widgets/simple_grouped_chips.dart
@@ -29,7 +29,7 @@ class SimpleGroupedChips<T> extends StatefulWidget {
   final List<T> values;
   final List<String> itemTitle;
   final List<String>? disabledItems;
-  final onChanged? onItemSelected;
+  final OnChanged? onItemSelected;
 
   SimpleGroupedChips({
     Key? key,

--- a/lib/src/widgets/simple_grouped_chips.dart
+++ b/lib/src/widgets/simple_grouped_chips.dart
@@ -22,11 +22,11 @@ import 'simple_grouped_checkbox.dart';
 ///
 /// [disabledColor]         : (Color) the Color that uses when the item is disabled
 ///
-/// [chipGroupStyle]
+/// [chipGroupStyle]        :  (ChipGroupStyle) the style that will customize  SimpleGroupedChips
 ///
-///  [values]               :(required) Values contains in each element.
+///  [values]               : (required) Values contains in each element.
 ///
-///  [itemTitle] :(required) A list of strings that describes each chip button
+///  [itemTitle]            : (required) A list of strings that describes each chip button
 ///
 ///  [onItemSelected] : callback listener when item is selected
 ///

--- a/lib/src/widgets/simple_grouped_chips.dart
+++ b/lib/src/widgets/simple_grouped_chips.dart
@@ -5,27 +5,48 @@ import '../common/item.dart';
 import '../common/state_group.dart';
 import 'simple_grouped_checkbox.dart';
 
-///  [controller] : A list of values that you want to be initially selected.
-///  [isScrolling] : enable horizontal scrolling
-///  [backgroundColorItem] : the background color for each item
-///  [selectedColorItem] : the background color to use when item is  selected
-///  [textColor] : the color to use for each text of item
-///  [selectedTextColor] :the selected color to use for each text of item
-///  [selectedIcon] :the selected icon to use for each selected  item
-///  [values] :(required) Values contains in each element.
+///
+///  [controller]            : A list of values that you want to be initially selected.
+///
+///  [isScrolling]           : enable horizontal scrolling
+///
+///  [backgroundColorItem]   : the background color for each item
+///
+///  [selectedColorItem]     : the background color to use when item is  selected
+///
+///  [textColor]            : the color to use for each text of item
+///
+///  [selectedTextColor]    : the selected color to use for each text of item
+///
+///  [selectedIcon]         : the selected icon to use for each selected  item
+///
+/// [disabledColor]         : (Color) the Color that uses when the item is disabled
+///
+/// [chipGroupStyle]
+///
+///  [values]               :(required) Values contains in each element.
+///
 ///  [itemTitle] :(required) A list of strings that describes each chip button
+///
 ///  [onItemSelected] : callback listener when item is selected
+///
 ///  [disabledItems] : Specifies which item should be disabled
-
 class SimpleGroupedChips<T> extends StatefulWidget {
   final GroupController controller;
   final bool isScrolling;
+  @Deprecated("should use `chipGroupStyle`,will be remove in next version")
   final Color backgroundColorItem;
+  @Deprecated("should use `chipGroupStyle`,will be remove in next version")
   final Color? disabledColor;
+  @Deprecated("should use `chipGroupStyle`,will be remove in next version")
   final Color selectedColorItem;
+  @Deprecated("should use `chipGroupStyle`,will be remove in next version")
   final Color textColor;
+  @Deprecated("should use `chipGroupStyle`,will be remove in next version")
   final Color selectedTextColor;
+  @Deprecated("should use `chipGroupStyle`,will be remove in next version")
   final IconData? selectedIcon;
+  final ChipGroupStyle chipGroupStyle;
   final List<T> values;
   final List<String> itemTitle;
   final List<String>? disabledItems;
@@ -44,6 +65,7 @@ class SimpleGroupedChips<T> extends StatefulWidget {
     this.selectedTextColor = Colors.white,
     this.textColor = Colors.black,
     this.selectedIcon = Icons.done,
+    this.chipGroupStyle = const ChipGroupStyle.minimize(),
     this.isScrolling = false,
   })  : assert(
             disabledItems == null ||
@@ -73,9 +95,24 @@ class SimpleGroupedChips<T> extends StatefulWidget {
 }
 
 class SimpleGroupedChipsState<T> extends StateGroup<T, SimpleGroupedChips> {
+  late final ChipGroupStyle groupStyle;
+
   @override
   void initState() {
     super.initState();
+    groupStyle = ChipGroupStyle(
+      backgroundColorItem: widget.chipGroupStyle.backgroundColorItem ??
+          widget.backgroundColorItem,
+      selectedColorItem:
+          widget.chipGroupStyle.selectedColorItem ?? widget.selectedColorItem,
+      textColor: widget.chipGroupStyle.textColor ?? widget.textColor,
+      selectedTextColor:
+          widget.chipGroupStyle.selectedTextColor ?? widget.selectedTextColor,
+      disabledColor:
+          widget.chipGroupStyle.disabledColor ?? widget.disabledColor,
+      selectedIcon: widget.chipGroupStyle.selectedIcon ?? widget.selectedIcon,
+      itemTitleStyle: widget.chipGroupStyle.itemTitleStyle,
+    );
     init(
       values: widget.values as List<T>,
       checkFirstElement: false,
@@ -118,43 +155,50 @@ class SimpleGroupedChipsState<T> extends StateGroup<T, SimpleGroupedChips> {
 
   @override
   Widget build(BuildContext context) {
+    final childrens = [
+      for (int i = 0; i < notifierItems.length; i++) ...[
+        ValueListenableBuilder(
+          valueListenable: notifierItems[i],
+          builder: (ctx, dynamic item, child) {
+            return _ChoiceChipsWidget(
+              onSelection: (v) {
+                changeSelection(i, v);
+              },
+              selectedIcon: groupStyle.selectedIcon != null
+                  ? Icon(
+                      groupStyle.selectedIcon,
+                      color: groupStyle.selectedTextColor,
+                    )
+                  : null,
+              isSelected: item.checked,
+              label: Text(
+                "${item.title}",
+                style: groupStyle.itemTitleStyle?.copyWith(
+                      color: item.checked
+                          ? groupStyle.selectedTextColor
+                          : groupStyle.textColor,
+                    ) ??
+                    TextStyle(
+                      color: item.checked
+                          ? groupStyle.selectedTextColor
+                          : groupStyle.textColor,
+                    ),
+              ),
+              backgroundColorItem: widget.chipGroupStyle.backgroundColorItem ??
+                  groupStyle.backgroundColorItem,
+              disabledColor: groupStyle.disabledColor,
+              selectedColorItem: groupStyle.selectedColorItem,
+            );
+          },
+        ),
+      ],
+    ];
     if (widget.isScrolling) {
       return SingleChildScrollView(
         child: Wrap(
           spacing: 15.0,
           direction: Axis.horizontal,
-          children: [
-            for (int i = 0; i < notifierItems.length; i++) ...[
-              ValueListenableBuilder(
-                valueListenable: notifierItems[i],
-                builder: (ctx, dynamic item, child) {
-                  return _ChoiceChipsWidget(
-                    onSelection: (v) {
-                      changeSelection(i, v);
-                    },
-                    selectedIcon: widget.selectedIcon != null
-                        ? Icon(
-                            widget.selectedIcon,
-                            color: widget.selectedTextColor,
-                          )
-                        : null,
-                    isSelected: item.checked,
-                    label: Text(
-                      "${item.title}",
-                      style: TextStyle(
-                        color: item.checked
-                            ? widget.selectedTextColor
-                            : widget.textColor,
-                      ),
-                    ),
-                    backgroundColorItem: widget.backgroundColorItem,
-                    disabledColor: widget.disabledColor,
-                    selectedColorItem: widget.selectedColorItem,
-                  );
-                },
-              ),
-            ],
-          ],
+          children: childrens,
         ),
         scrollDirection: Axis.horizontal,
       );
@@ -163,38 +207,7 @@ class SimpleGroupedChipsState<T> extends StateGroup<T, SimpleGroupedChips> {
       spacing: 5.0,
       direction: Axis.horizontal,
       verticalDirection: VerticalDirection.down,
-      children: [
-        for (int i = 0; i < notifierItems.length; i++) ...[
-          ValueListenableBuilder(
-            valueListenable: notifierItems[i],
-            builder: (ctx, dynamic item, child) {
-              return _ChoiceChipsWidget(
-                onSelection: (v) {
-                  changeSelection(i, v);
-                },
-                selectedIcon: widget.selectedIcon != null
-                    ? Icon(
-                        widget.selectedIcon,
-                        color: widget.selectedTextColor,
-                      )
-                    : null,
-                isSelected: item.checked,
-                label: Text(
-                  "${item.title}",
-                  style: TextStyle(
-                    color: item.checked
-                        ? widget.selectedTextColor
-                        : widget.textColor,
-                  ),
-                ),
-                backgroundColorItem: widget.backgroundColorItem,
-                disabledColor: widget.disabledColor,
-                selectedColorItem: widget.selectedColorItem,
-              );
-            },
-          ),
-        ],
-      ],
+      children: childrens,
     );
   }
 

--- a/lib/src/widgets/simple_grouped_switch.dart
+++ b/lib/src/widgets/simple_grouped_switch.dart
@@ -20,14 +20,18 @@ class SimpleGroupedSwitch<T> extends StatefulWidget {
   final GroupController controller;
   final List<T> disableItems;
   final OnChanged? onItemSelected;
+  @Deprecated("should use `groupStyle`,will be remove in next version")
   final Color? activeColor;
+  @Deprecated("should use `groupStyle`,will be remove in next version")
   final TextStyle? textStyle;
+  final SwitchGroupStyle? groupStyle;
 
   SimpleGroupedSwitch({
     Key? key,
     required this.itemsTitle,
     required this.values,
     required this.controller,
+    this.groupStyle,
     this.disableItems = const [],
     this.activeColor,
     this.textStyle,
@@ -114,8 +118,12 @@ class SimpleGroupedSwitchState<T> extends StateGroup<T, SimpleGroupedSwitch> {
               indexItem: index,
               onItemChanged: changeSelection,
               item: item,
-              activeColor: widget.activeColor,
-              textStyle: widget.textStyle,
+              activeColor: widget.groupStyle?.activeColor ?? widget.activeColor,
+              textStyle: widget.groupStyle?.itemTitleStyle?.copyWith(
+                      color: item.checked!
+                          ? widget.groupStyle?.activeColor ?? widget.activeColor
+                          : widget.groupStyle?.itemTitleStyle?.color) ??
+                  widget.textStyle,
             );
           },
         );
@@ -202,14 +210,7 @@ class _SwitchListItem extends StatelessWidget {
       value: item.checked!,
       title: Text(
         "${item.title}",
-        style: textStyle?.copyWith(
-          color: item.checked!
-              ? activeColor
-              : (textStyle?.color ??
-                      Theme.of(context).textTheme.headline6!.color) ??
-                  Theme.of(context).textTheme.headline6!.getTextStyle()
-                      as Color?,
-        ),
+        style: textStyle,
       ),
     );
   }

--- a/lib/src/widgets/simple_grouped_switch.dart
+++ b/lib/src/widgets/simple_grouped_switch.dart
@@ -19,7 +19,7 @@ class SimpleGroupedSwitch<T> extends StatefulWidget {
   final List<T> values;
   final GroupController controller;
   final List<T> disableItems;
-  final onChanged? onItemSelected;
+  final OnChanged? onItemSelected;
   final Color? activeColor;
   final TextStyle? textStyle;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: checkbox_grouped
 description: flutter widget that grouping checkbox, recuperate the actual selection,support multiple selection
-version: 1.4.2
+version: 1.5.0
 homepage: https://github.com/liodali/grouped_checkbox
 authors:
   - Mohamed ali hamza <hamza.mohamedali93@gmail.com>


### PR DESCRIPTION
*  create new generic `GroupedStyle` to manage style of simple_grouped_checkbox 
*  deprecate `backgroundColorItem`,`selectedColorItem`,`textColor`,`selectedTextColor`,`selectedIcon`,`disabledColor` 
*  add `chipGroupStyle` in SimpleGroupedChips 
*  add `SwitchGroupStyle` style for SimpleGroupedSwitch 
*  add `SwitchGroupStyle` style for SimpleGroupedSwitch 